### PR TITLE
Fix filter to return content

### DIFF
--- a/lib/nanoc/filters/gzip.rb
+++ b/lib/nanoc/filters/gzip.rb
@@ -9,11 +9,13 @@ module Nanoc::Filters
     type :text
 
     def run(content, params = {})
-      Zlib::GzipWriter.open(output_filename, Zlib::BEST_COMPRESSION) do |gz|
+      out = StringIO.new
+      Zlib::GzipWriter.wrap(out, Zlib::BEST_COMPRESSION) do |gz|
         gz.orig_name = File.basename(item[:filename])
         gz.mtime = mtime.to_i
         gz.write content
       end
+      out.string
     end
 
     def mtime


### PR DESCRIPTION
Hi!
First of all, thank you for your filter rework!

I'm using Ruby 2.3.3 and nanoc 4.6.2. I've got problems running your filter.

Looking on my nanoc's built-in filters I found out that filter's `run` method should return content. So here's the patch.